### PR TITLE
Fixed loop class constructor

### DIFF
--- a/Messaging/Loop.cpp
+++ b/Messaging/Loop.cpp
@@ -4,6 +4,7 @@ namespace LiveFreetimeLooper
 {
     Loop::Loop(std::unique_ptr<Message> controlMessage) :
         _interval(0),
+        _waitUntilNextRestart(0),
         _controlMessage(std::move(controlMessage))
     {
 


### PR DESCRIPTION
_waitUntilNextRestart value is now initialized to 0 by constructor. I think we were relying on undefined behavior here.
